### PR TITLE
Implement dynamic timestamp types in Message class

### DIFF
--- a/mockafka/message.py
+++ b/mockafka/message.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import time
-from typing import Optional, Any
+from typing import Any, Optional
 
-from confluent_kafka import KafkaError  # type: ignore[import-untyped]
+from confluent_kafka import (
+    TIMESTAMP_CREATE_TIME,
+    TIMESTAMP_LOG_APPEND_TIME,
+    TIMESTAMP_NOT_AVAILABLE,
+    KafkaError,
+)
 
 
 class Message:
@@ -18,42 +23,53 @@ class Message:
         self._leader_epoch: Optional[int] = kwargs.get("leader_epoch", None)
         self._partition: Optional[int] = kwargs.get("partition", None)
         self._timestamp: int = kwargs.get("timestamp") or int(time.time() * 1000)
+        self._timestamp_type = kwargs.get("timestamp_type", TIMESTAMP_CREATE_TIME)
+        self._broker_receive_time = kwargs.get("broker_receive_time") or int(
+            time.time() * 1000
+        )
 
-    def offset(self, *args, **kwargs):
+    def offset(self, *args, **kwargs) -> int | None:
         return self._offset
 
-    def latency(self, *args, **kwargs):
+    def latency(self, *args, **kwargs) -> float | None:
         return self._latency
 
-    def leader_epoch(self, *args, **kwargs):
+    def leader_epoch(self, *args, **kwargs) -> int | None:
         return self._leader_epoch
 
-    def headers(self, *args, **kwargs):
+    def headers(self, *args, **kwargs) -> dict | None:
         return self._headers
 
-    def key(self, *args, **kwargs):
+    def key(self, *args, **kwargs) -> str | None:
         return self._key
 
-    def value(self, *args, **kwargs):
+    def value(self, *args, **kwargs) -> str | None:
         return self._value
 
-    def timestamp(self, *args, **kwargs):
-        return self._timestamp
+    def timestamp(self, *args, **kwargs) -> tuple[int, int]:
+        ts_info = tuple()
+        if self._timestamp_type == TIMESTAMP_NOT_AVAILABLE:
+            ts_info = (TIMESTAMP_NOT_AVAILABLE, 0)
+        elif self._timestamp_type == TIMESTAMP_LOG_APPEND_TIME:
+            ts_info = (TIMESTAMP_LOG_APPEND_TIME, self._broker_receive_time)
+        else:
+            ts_info = (self._timestamp_type, self._timestamp)
+        return ts_info
 
-    def topic(self, *args, **kwargs):
+    def topic(self, *args, **kwargs) -> str | None:
         return self._topic
 
-    def partition(self, *args, **kwargs):
+    def partition(self, *args, **kwargs) -> int | None:
         return self._partition
 
-    def error(self):
+    def error(self) -> Any | None:
         return self._error
 
-    def set_headers(self, *args, **kwargs):  # real signature unknown
+    def set_headers(self, *args, **kwargs) -> None:  # real signature unknown
         pass
 
-    def set_key(self, *args, **kwargs):  # real signature unknown
+    def set_key(self, *args, **kwargs) -> None:  # real signature unknown
         pass
 
-    def set_value(self, *args, **kwargs):  # real signature unknown
+    def set_value(self, *args, **kwargs) -> None:  # real signature unknown
         pass


### PR DESCRIPTION
Aligning with confluent-kafka behavior,
Implemented broker receive time simulation for 
Updated timestamp() method to return a ```tuple[int, int]``` as per confluent-kafka specs. 